### PR TITLE
feat(zsh): add substring and case-insensitive completion

### DIFF
--- a/configs/.zshrc
+++ b/configs/.zshrc
@@ -27,6 +27,9 @@ if [[ -f /opt/homebrew/share/zsh-completions ]]; then
 fi
 autoload -Uz compinit && compinit
 
+# Substring + case-insensitive completion
+zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|=*' 'l:|=*'
+
 # ─── History ─────────────────────────────────────────────────────────
 HISTSIZE=50000
 SAVEHIST=50000


### PR DESCRIPTION
Enable substring matching in zsh tab completion so that typing 'workspace' can match 'oms-workspace'. Also adds case-insensitive matching via m:{a-zA-Z}={A-Za-z}.
中段 tab键补全