### PR TITLE
fix: move zsh-syntax-highlighting to the end of .zshrc

### DIFF
--- a/configs/.zshrc
+++ b/configs/.zshrc
@@ -17,13 +17,6 @@ fi
 eval "$(starship init zsh)"
 
 # ─── Zsh plugins (via Homebrew) ──────────────────────────────────────
-# Syntax highlighting (must be before autosuggestions for best results)
-if [[ -n "$BREW_PREFIX" && -f "$BREW_PREFIX/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" ]]; then
-    source "$BREW_PREFIX/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
-elif [[ -f /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ]]; then
-    source /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
-fi
-
 # Autosuggestions (fish-like suggestions)
 if [[ -n "$BREW_PREFIX" && -f "$BREW_PREFIX/share/zsh-autosuggestions/zsh-autosuggestions.zsh" ]]; then
     source "$BREW_PREFIX/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
@@ -119,3 +112,12 @@ case ":$PATH:" in
     *":$PNPM_HOME:"*) ;;
     *) export PATH="$PNPM_HOME:$PATH" ;;
 esac
+
+# ─── zsh-syntax-highlighting ──────────────────────────────────────────
+# Load this at the very end of .zshrc so widgets created by compinit,
+# zle -N, and other plugins are included in syntax highlighting.
+if [[ -n "$BREW_PREFIX" && -f "$BREW_PREFIX/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" ]]; then
+    source "$BREW_PREFIX/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+elif [[ -f /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ]]; then
+    source /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+fi


### PR DESCRIPTION
## Summary
- move `zsh-syntax-highlighting` loading to the end of `configs/.zshrc`
- keep the existing Homebrew and `/usr/share` fallback paths
- add an inline comment explaining why it must be loaded last

## Why
The official `zsh-syntax-highlighting` README states that it should be sourced after all custom widgets are created, i.e. after all `zle -N` calls and after `compinit`; otherwise widgets created later will not update syntax highlighting correctly.

In this repo, `zsh-syntax-highlighting` was loaded before:
- `autoload -Uz compinit && compinit`
- `zle -N up-line-or-beginning-search`
- `zle -N down-line-or-beginning-search`

This PR moves it to the end of `.zshrc` to match the upstream recommendation.

## Validation
- `zsh -n configs/.zshrc`

Closes #11