### PR TITLE
feat: add Arch Linux support (pacman)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: '.'
+          severity: style
+
+  bats:
+    name: BATS tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install BATS
+        run: sudo apt-get update && sudo apt-get install -y bats
+      - name: Run tests
+        run: cd tests && ./run_tests.sh
+
+  arch-docker:
+    name: Arch Linux (Docker)
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+    steps:
+      - name: Install system dependencies
+        run: |
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm bats git base-devel
+      - uses: actions/checkout@v4
+      - name: Run BATS tests
+        run: cd tests && ./run_tests.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 *.bak.*
+相关资料.txt
+doc/

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+shell=bash

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🖥️ terminal-setup
 
-One-script terminal environment setup for **macOS**, **Debian/Ubuntu**, and **Windows (WSL)**. Run on a fresh machine, get a fully configured terminal in minutes.
+One-script terminal environment setup for **macOS**, **Arch Linux**, **Debian/Ubuntu**, and **Windows (WSL)**. Run on a fresh machine, get a fully configured terminal in minutes.
 
 **🇨🇳 [中文版文档](README_CN.md)**
 
@@ -23,15 +23,23 @@ One-script terminal environment setup for **macOS**, **Debian/Ubuntu**, and **Wi
 | Platform | Status | Package Manager |
 |----------|--------|----------------|
 | 🍎 **macOS** | ✅ Primary — battle-tested | Homebrew |
+| 🐧 **Arch Linux** | 🧪 Experimental — works but not extensively tested | pacman |
 | 🐧 **Debian / Ubuntu** | 🧪 Experimental — works but not extensively tested | apt + bundled binaries |
 | 🪟 **Windows (WSL)** | 🧪 Experimental — works but not extensively tested | apt (inside WSL) |
 | 🪟 **Windows (native)** | ⛔ Not supported | Use WSL instead |
 
-> **Note:** This script is primarily developed and tested on macOS. Linux (Debian/Ubuntu) and WSL support has been added and works, but has not gone through long-term usage testing. Issues and PRs welcome!
+> **Note:** This script is primarily developed and tested on macOS. Linux (Arch, Debian/Ubuntu) and WSL support has been added and works, but has not gone through long-term usage testing. Issues and PRs welcome!
 
 ## Quick Start
 
 ### macOS
+
+```bash
+git clone https://github.com/lewislulu/terminal-setup.git
+cd terminal-setup && ./setup.sh
+```
+
+### Arch Linux
 
 ```bash
 git clone https://github.com/lewislulu/terminal-setup.git
@@ -112,7 +120,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/lewislulu/terminal-setup/mai
 2. Installs **Ghostty** terminal (macOS; Linux users install separately)
 3. Downloads **MesloLGS NF** nerd fonts
 4. Installs your **shell** of choice + plugins
-5. Installs all **CLI tools** (Homebrew on macOS, apt + GitHub releases on Linux)
+5. Installs all **CLI tools** (Homebrew on macOS, pacman on Arch Linux, apt + GitHub releases on Debian)
 6. Installs **Starship** prompt with Catppuccin Mocha config
 7. Installs **fnm** + **Node.js** LTS (optional)
 8. Installs **Zellij** terminal multiplexer (optional)
@@ -123,6 +131,14 @@ bash <(curl -fsSL https://raw.githubusercontent.com/lewislulu/terminal-setup/mai
 ### macOS
 - Full support, everything installs via Homebrew
 - Ghostty installs as a native macOS app
+
+### Arch Linux
+- All CLI tools install via pacman (`sudo pacman -S`)
+- `bat` and `fd` use standard names — no symlinks needed
+- Fonts install to `~/.local/share/fonts/`, also available via `ttf-meslo-nerd-font`
+- Ghostty is available in the [community] repo — install via pacman directly
+- Zsh plugins install via pacman or git clone
+- Does not require AUR helpers (uses official repos only)
 
 ### Debian / Ubuntu
 - CLI tools install via apt where available, GitHub releases for others (delta, lazygit, eza)

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,6 +1,6 @@
 # 🖥️ terminal-setup
 
-一键配置终端环境，支持 **macOS**、**Debian/Ubuntu** 和 **Windows (WSL)**。新机器跑一个脚本，几分钟搞定完整终端。
+一键配置终端环境，支持 **macOS**、**Arch Linux**、**Debian/Ubuntu** 和 **Windows (WSL)**。新机器跑一个脚本，几分钟搞定完整终端。
 
 **🇬🇧 [English Version](README.md)**
 
@@ -23,15 +23,23 @@
 | 平台 | 状态 | 包管理器 |
 |------|------|---------|
 | 🍎 **macOS** | ✅ 主力平台 — 长期使用验证 | Homebrew |
+| 🐧 **Arch Linux** | 🧪 实验性 — 可用但未经长期测试 | pacman |
 | 🐧 **Debian / Ubuntu** | 🧪 实验性 — 可用但未经长期测试 | apt + 内置二进制 |
 | 🪟 **Windows (WSL)** | 🧪 实验性 — 可用但未经长期测试 | apt（WSL 内部） |
 
-> **注意：** 本脚本主要在 macOS 上开发和测试。Linux（Debian/Ubuntu）和 WSL 支持已添加且可用，但尚未经过长期使用测试。欢迎提 Issue 和 PR！
+> **注意：** 本脚本主要在 macOS 上开发和测试。Linux（Arch、Debian/Ubuntu）和 WSL 支持已添加且可用，但尚未经过长期使用测试。欢迎提 Issue 和 PR！
 | 🪟 **Windows (原生)** | ⛔ 不支持 | 请先安装 WSL |
 
 ## 快速开始
 
 ### macOS
+
+```bash
+git clone https://github.com/lewislulu/terminal-setup.git
+cd terminal-setup && ./setup.sh
+```
+
+### Arch Linux
 
 ```bash
 git clone https://github.com/lewislulu/terminal-setup.git
@@ -112,7 +120,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/lewislulu/terminal-setup/mai
 2. 安装 **Ghostty** 终端（macOS；Linux 需手动安装）
 3. 下载 **MesloLGS NF** Nerd 字体
 4. 安装你选择的 **Shell** + 插件
-5. 安装所有 **CLI 工具**（macOS 用 Homebrew，Linux 用 apt + GitHub releases）
+5. 安装所有 **CLI 工具**（macOS 用 Homebrew，Arch Linux 用 pacman，Debian 用 apt + GitHub releases）
 6. 安装 **Starship** 提示符 + Catppuccin Mocha 配置
 7. 安装 **fnm** + **Node.js** LTS（可选）
 8. 安装 **Zellij** 终端复用器（可选）
@@ -123,6 +131,14 @@ bash <(curl -fsSL https://raw.githubusercontent.com/lewislulu/terminal-setup/mai
 ### macOS
 - 完整支持，所有工具通过 Homebrew 安装
 - Ghostty 作为原生 macOS 应用安装
+
+### Arch Linux
+- 所有 CLI 工具优先通过 pacman 安装（`sudo pacman -S`）
+- `bat`、`fd` 包名即标准名，无需创建软链接
+- 字体安装到 `~/.local/share/fonts/`，也可通过 `ttf-meslo-nerd-font` 包安装
+- Ghostty 在 [community] 仓库中，直接用 pacman 安装
+- Zsh 插件通过 pacman 或 git clone 安装
+- 不依赖 AUR 助手（仅使用官方仓库）
 
 ### Debian / Ubuntu
 - CLI 工具优先用 apt 安装，apt 没有的从 GitHub releases 下载（delta、lazygit、eza）

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 #
 # terminal-setup — One-script terminal environment setup
 #
-# Platforms: macOS, Debian/Ubuntu, Windows (via WSL)
+# Platforms: macOS, Debian/Ubuntu, Arch Linux, Windows (via WSL)
 #
 # Stack: Ghostty + (Fish or Zsh) + Starship + Nerd Font (MesloLGS)
 # Tools: bat, eza, fd, ripgrep, btop, zoxide, jq, tldr, delta, lazygit, fzf
@@ -73,6 +73,8 @@ detect_os() {
             # Check if running inside WSL
             if grep -qiE '(microsoft|wsl)' /proc/version 2>/dev/null; then
                 echo "wsl"
+            elif [[ -f /etc/arch-release ]] || grep -qi 'arch' /etc/os-release 2>/dev/null; then
+                echo "arch"
             elif [[ -f /etc/debian_version ]] || grep -qi 'debian\|ubuntu' /etc/os-release 2>/dev/null; then
                 echo "debian"
             else
@@ -94,6 +96,9 @@ case "$OS" in
     macos)
         info "Detected ${BOLD}macOS${NC}"
         ;;
+    arch)
+        info "Detected ${BOLD}Arch Linux${NC}"
+        ;;
     debian)
         info "Detected ${BOLD}Debian/Ubuntu Linux${NC}"
         ;;
@@ -104,7 +109,7 @@ case "$OS" in
         error "Native Windows (MINGW/MSYS/Cygwin) is not supported.\n  Please install WSL: https://learn.microsoft.com/en-us/windows/wsl/install\n  Then run this script inside WSL."
         ;;
     *)
-        error "Unsupported OS: $(uname -s)\n  This script supports macOS, Debian/Ubuntu, and Windows WSL."
+        error "Unsupported OS: $(uname -s)\n  This script supports macOS, Debian/Ubuntu, Arch Linux, and Windows WSL."
         ;;
 esac
 
@@ -157,6 +162,14 @@ pkg_install() {
             fi
             info "Installing $pkg..."
             run_cmd brew install "$pkg"
+            ;;
+        arch)
+            if pacman -Qi "$pkg" &>/dev/null 2>&1; then
+                success "$pkg already installed"
+                return 0
+            fi
+            info "Installing $pkg..."
+            run_cmd sudo pacman -S --noconfirm "$pkg"
             ;;
         debian|wsl)
             if dpkg -s "$pkg" &>/dev/null 2>&1; then
@@ -213,6 +226,17 @@ case "$OS" in
             success "Homebrew already installed"
         fi
         ;;
+    arch)
+        info "Updating pacman package database..."
+        run_cmd sudo pacman -Syu --noconfirm
+        # Ensure basic build tools are available
+        pkg_install "curl"
+        pkg_install "git"
+        pkg_install "wget"
+        pkg_install "unzip"
+        pkg_install "base-devel"
+        success "pacman package manager ready"
+        ;;
     debian|wsl)
         info "Updating apt package index..."
         run_cmd sudo apt-get update
@@ -240,6 +264,15 @@ case "$OS" in
             success "Ghostty installed"
         else
             success "Ghostty already installed"
+        fi
+        ;;
+    arch)
+        if has_cmd ghostty; then
+            success "Ghostty already installed"
+        else
+            info "Installing Ghostty..."
+            run_cmd sudo pacman -S --noconfirm ghostty
+            success "Ghostty installed"
         fi
         ;;
     debian)
@@ -275,7 +308,7 @@ case "$OS" in
     macos)
         FONT_DIR="$HOME/Library/Fonts"
         ;;
-    debian|wsl)
+    arch|debian|wsl)
         FONT_DIR="$HOME/.local/share/fonts"
         ;;
 esac
@@ -309,7 +342,7 @@ else
         fi
     done
     # Rebuild font cache on Linux
-    if [[ "$OS" == "debian" || "$OS" == "wsl" ]]; then
+    if [[ "$OS" == "debian" || "$OS" == "arch" || "$OS" == "wsl" ]]; then
         if has_cmd fc-cache; then
             run_cmd fc-cache -fv "$FONT_DIR"
         fi
@@ -377,14 +410,19 @@ install_shell_macos() {
 install_shell_linux() {
     if [[ "$SHELL_CHOICE" == "fish" ]]; then
         if ! has_cmd fish; then
-            # Fish PPA for latest version on Ubuntu/Debian
-            if [[ -f /etc/lsb-release ]] && grep -qi ubuntu /etc/lsb-release 2>/dev/null; then
-                info "Adding Fish PPA for latest version..."
-                run_cmd sudo apt-add-repository -y ppa:fish-shell/release-3
-                run_cmd sudo apt-get update
+            if [[ "$OS" == "arch" ]]; then
+                info "Installing Fish..."
+                run_cmd sudo pacman -S --noconfirm fish
+            else
+                # Fish PPA for latest version on Ubuntu/Debian
+                if [[ -f /etc/lsb-release ]] && grep -qi ubuntu /etc/lsb-release 2>/dev/null; then
+                    info "Adding Fish PPA for latest version..."
+                    run_cmd sudo apt-add-repository -y ppa:fish-shell/release-3
+                    run_cmd sudo apt-get update
+                fi
+                info "Installing Fish..."
+                run_cmd sudo apt-get install -y fish
             fi
-            info "Installing Fish..."
-            run_cmd sudo apt-get install -y fish
             success "Fish installed"
         else
             success "Fish already installed"
@@ -407,42 +445,77 @@ install_shell_linux() {
         # Install Zsh if not present
         if ! has_cmd zsh; then
             info "Installing Zsh..."
-            run_cmd sudo apt-get install -y zsh
+            if [[ "$OS" == "arch" ]]; then
+                run_cmd sudo pacman -S --noconfirm zsh
+            else
+                run_cmd sudo apt-get install -y zsh
+            fi
             success "Zsh installed"
         else
             success "Zsh already installed"
         fi
 
-        # Install Zsh plugins from apt or git clone
+        # Install Zsh plugins
         local ZSH_PLUGINS_DIR="/usr/share"
-        local need_clone=false
 
-        # zsh-autosuggestions
-        if [[ -f "$ZSH_PLUGINS_DIR/zsh-autosuggestions/zsh-autosuggestions.zsh" ]]; then
-            success "zsh-autosuggestions already installed"
-        elif dpkg -s zsh-autosuggestions &>/dev/null 2>&1; then
-            success "zsh-autosuggestions already installed"
-        else
-            info "Installing zsh-autosuggestions..."
-            run_cmd sudo apt-get install -y zsh-autosuggestions 2>/dev/null || {
-                info "apt package not available, cloning from git..."
-                run_cmd sudo git clone https://github.com/zsh-users/zsh-autosuggestions "$ZSH_PLUGINS_DIR/zsh-autosuggestions"
-            }
-            success "zsh-autosuggestions installed"
-        fi
+        if [[ "$OS" == "arch" ]]; then
+            # Arch: try pacman first, then git clone
+            # zsh-autosuggestions
+            if [[ -f "$ZSH_PLUGINS_DIR/zsh-autosuggestions/zsh-autosuggestions.zsh" ]]; then
+                success "zsh-autosuggestions already installed"
+            elif pacman -Qi zsh-autosuggestions &>/dev/null 2>&1; then
+                success "zsh-autosuggestions already installed"
+            else
+                info "Installing zsh-autosuggestions..."
+                run_cmd sudo pacman -S --noconfirm zsh-autosuggestions 2>/dev/null || {
+                    info "pacman package not available, cloning from git..."
+                    run_cmd sudo git clone https://github.com/zsh-users/zsh-autosuggestions "$ZSH_PLUGINS_DIR/zsh-autosuggestions"
+                }
+                success "zsh-autosuggestions installed"
+            fi
 
-        # zsh-syntax-highlighting
-        if [[ -f "$ZSH_PLUGINS_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" ]]; then
-            success "zsh-syntax-highlighting already installed"
-        elif dpkg -s zsh-syntax-highlighting &>/dev/null 2>&1; then
-            success "zsh-syntax-highlighting already installed"
+            # zsh-syntax-highlighting
+            if [[ -f "$ZSH_PLUGINS_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" ]]; then
+                success "zsh-syntax-highlighting already installed"
+            elif pacman -Qi zsh-syntax-highlighting &>/dev/null 2>&1; then
+                success "zsh-syntax-highlighting already installed"
+            else
+                info "Installing zsh-syntax-highlighting..."
+                run_cmd sudo pacman -S --noconfirm zsh-syntax-highlighting 2>/dev/null || {
+                    info "pacman package not available, cloning from git..."
+                    run_cmd sudo git clone https://github.com/zsh-users/zsh-syntax-highlighting "$ZSH_PLUGINS_DIR/zsh-syntax-highlighting"
+                }
+                success "zsh-syntax-highlighting installed"
+            fi
         else
-            info "Installing zsh-syntax-highlighting..."
-            run_cmd sudo apt-get install -y zsh-syntax-highlighting 2>/dev/null || {
-                info "apt package not available, cloning from git..."
-                run_cmd sudo git clone https://github.com/zsh-users/zsh-syntax-highlighting "$ZSH_PLUGINS_DIR/zsh-syntax-highlighting"
-            }
-            success "zsh-syntax-highlighting installed"
+            # Debian/WSL: try apt first, then git clone
+            # zsh-autosuggestions
+            if [[ -f "$ZSH_PLUGINS_DIR/zsh-autosuggestions/zsh-autosuggestions.zsh" ]]; then
+                success "zsh-autosuggestions already installed"
+            elif dpkg -s zsh-autosuggestions &>/dev/null 2>&1; then
+                success "zsh-autosuggestions already installed"
+            else
+                info "Installing zsh-autosuggestions..."
+                run_cmd sudo apt-get install -y zsh-autosuggestions 2>/dev/null || {
+                    info "apt package not available, cloning from git..."
+                    run_cmd sudo git clone https://github.com/zsh-users/zsh-autosuggestions "$ZSH_PLUGINS_DIR/zsh-autosuggestions"
+                }
+                success "zsh-autosuggestions installed"
+            fi
+
+            # zsh-syntax-highlighting
+            if [[ -f "$ZSH_PLUGINS_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" ]]; then
+                success "zsh-syntax-highlighting already installed"
+            elif dpkg -s zsh-syntax-highlighting &>/dev/null 2>&1; then
+                success "zsh-syntax-highlighting already installed"
+            else
+                info "Installing zsh-syntax-highlighting..."
+                run_cmd sudo apt-get install -y zsh-syntax-highlighting 2>/dev/null || {
+                    info "apt package not available, cloning from git..."
+                    run_cmd sudo git clone https://github.com/zsh-users/zsh-syntax-highlighting "$ZSH_PLUGINS_DIR/zsh-syntax-highlighting"
+                }
+                success "zsh-syntax-highlighting installed"
+            fi
         fi
 
         ZSH_PATH="$(which zsh)"
@@ -458,7 +531,7 @@ install_shell_linux() {
 
 case "$OS" in
     macos)  install_shell_macos ;;
-    debian|wsl) install_shell_linux ;;
+    arch|debian|wsl) install_shell_linux ;;
 esac
 
 # ─── Step 5: CLI Tools ──────────────────────────────────────────────
@@ -608,8 +681,16 @@ install_cli_tools_linux() {
     fi
 }
 
+install_cli_tools_arch() {
+    local PACMAN_TOOLS=(bat eza fd ripgrep btop zoxide jq tealdeer git-delta lazygit fzf)
+    for tool in "${PACMAN_TOOLS[@]}"; do
+        pkg_install "$tool"
+    done
+}
+
 case "$OS" in
     macos)      install_cli_tools_macos ;;
+    arch)       install_cli_tools_arch ;;
     debian|wsl) install_cli_tools_linux ;;
 esac
 
@@ -626,6 +707,10 @@ else
         macos)
             info "Installing Starship..."
             run_cmd brew install starship
+            ;;
+        arch)
+            info "Installing Starship..."
+            run_cmd sudo pacman -S --noconfirm starship
             ;;
         debian|wsl)
             info "Installing Starship..."
@@ -694,6 +779,10 @@ else
                 info "Installing fnm (Fast Node Manager)..."
                 run_cmd brew install fnm
                 ;;
+            arch)
+                info "Installing fnm (Fast Node Manager)..."
+                run_cmd sudo pacman -S --noconfirm fnm
+                ;;
             debian|wsl)
                 info "Installing fnm via official installer..."
                 run_cmd bash -c "$(curl -fsSL https://fnm.vercel.app/install)" -- --skip-shell
@@ -734,6 +823,10 @@ else
             macos)
                 info "Installing Zellij..."
                 run_cmd brew install zellij
+                ;;
+            arch)
+                info "Installing Zellij..."
+                run_cmd sudo pacman -S --noconfirm zellij
                 ;;
             debian|wsl)
                 info "Installing Zellij..."
@@ -782,7 +875,7 @@ deploy_ghostty_config() {
         macos)
             ghostty_config_dir="$HOME/Library/Application Support/com.mitchellh.ghostty"
             ;;
-        debian)
+        arch|debian)
             ghostty_config_dir="$HOME/.config/ghostty"
             ;;
         wsl)
@@ -805,7 +898,7 @@ deploy_ghostty_config() {
         macos)
             run_cmd cp "$CONFIGS_DIR/ghostty.config" "$ghostty_config_dir/config.ghostty"
             ;;
-        debian|wsl)
+        arch|debian|wsl)
             run_cmd cp "$CONFIGS_DIR/ghostty.config" "$ghostty_config_dir/config"
             ;;
     esac
@@ -894,7 +987,7 @@ FISHEOF
     fi
 
     # Add ~/.local/bin to fish PATH on Linux
-    if [[ "$OS" == "debian" || "$OS" == "wsl" ]]; then
+    if [[ "$OS" == "arch" || "$OS" == "debian" || "$OS" == "wsl" ]]; then
         if ! grep -qF '.local/bin' "$FISH_CONFIG_DIR/config.fish" 2>/dev/null; then
             echo '' >> "$FISH_CONFIG_DIR/config.fish"
             echo '# Local bin (Linux)' >> "$FISH_CONFIG_DIR/config.fish"
@@ -962,6 +1055,9 @@ echo -e ""
 echo -e "  ${BOLD}Your terminal stack:${NC}"
 case "$OS" in
     macos)
+        echo -e "    👻 Ghostty              — terminal emulator"
+        ;;
+    arch)
         echo -e "    👻 Ghostty              — terminal emulator"
         ;;
     debian)

--- a/tests/argument_parsing.bats
+++ b/tests/argument_parsing.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+# Tests for argument parsing (--fish, --zsh, --dry-run)
+
+setup() {
+    load 'test_helper'
+    setup_sandbox
+    setup_save_originals
+}
+
+teardown() {
+    teardown_sandbox
+}
+
+# Simulate argument parsing by sourcing argument parsing section of setup.sh
+parse_args_and_source() {
+    local script="$PWD/setup.sh"
+    local args=("$@")
+
+    # Reset state variables
+    SHELL_CHOICE=""
+    DRY_RUN=false
+
+    # Parse arguments using same logic as setup.sh
+    for arg in "${args[@]}"; do
+        case "$arg" in
+            --fish)    SHELL_CHOICE="fish" ;;
+            --zsh)     SHELL_CHOICE="zsh" ;;
+            --dry-run) DRY_RUN=true ;;
+        esac
+    done
+}
+
+@test "no arguments: SHELL_CHOICE is empty (will prompt)" {
+    parse_args_and_source
+    [[ -z "$SHELL_CHOICE" ]]
+}
+
+@test "--fish: SHELL_CHOICE is fish" {
+    parse_args_and_source --fish
+    [[ "$SHELL_CHOICE" == "fish" ]]
+}
+
+@test "--zsh: SHELL_CHOICE is zsh" {
+    parse_args_and_source --zsh
+    [[ "$SHELL_CHOICE" == "zsh" ]]
+}
+
+@test "--dry-run: DRY_RUN is true" {
+    parse_args_and_source --dry-run
+    $DRY_RUN
+}
+
+@test "--dry-run --fish: both flags parsed" {
+    parse_args_and_source --dry-run --fish
+    [[ "$SHELL_CHOICE" == "fish" ]]
+    $DRY_RUN
+}
+
+@test "--dry-run --zsh: both flags parsed" {
+    parse_args_and_source --dry-run --zsh
+    [[ "$SHELL_CHOICE" == "zsh" ]]
+    $DRY_RUN
+}
+
+@test "unknown argument is ignored" {
+    parse_args_and_source --unknown-flag --fish
+    [[ "$SHELL_CHOICE" == "fish" ]]
+}

--- a/tests/config_deployment.bats
+++ b/tests/config_deployment.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# Tests for config file deployment logic
+
+setup() {
+    load 'test_helper'
+    setup_sandbox
+}
+
+teardown() {
+    teardown_sandbox
+}
+
+# ── Config backup tests ──────────────────────────────────────────
+
+@test "existing config is backed up before overwrite" {
+    CONFIGS_DIR="$PWD/configs"
+
+    # Create a mock existing config
+    mkdir -p "$HOME/.config"
+    echo "existing config" > "$HOME/.config/starship.toml"
+
+    # Simulate backup logic
+    if [[ -f "$HOME/.config/starship.toml" ]]; then
+        cp "$HOME/.config/starship.toml" "$HOME/.config/starship.toml.bak.test"
+    fi
+    cp "$CONFIGS_DIR/starship.toml" "$HOME/.config/starship.toml"
+
+    # Verify backup exists
+    [[ -f "$HOME/.config/starship.toml.bak.test" ]]
+    [[ "$(cat "$HOME/.config/starship.toml.bak.test")" == "existing config" ]]
+    # Verify new config deployed
+    [[ "$(cat "$HOME/.config/starship.toml")" == "$(cat "$CONFIGS_DIR/starship.toml")" ]]
+}
+
+@test "backup has unique timestamp" {
+    # Verify that .bak.$(date +%s) produces a unique name each run
+    local ts1 ts2
+    ts1="config.bak.$(date +%s)"
+    sleep 1
+    ts2="config.bak.$(date +%s)"
+    [[ "$ts1" != "$ts2" ]]
+}
+
+@test "no existing config: no backup created, fresh deploy" {
+    CONFIGS_DIR="$PWD/configs"
+    mkdir -p "$HOME/.config"
+
+    [[ ! -f "$HOME/.config/starship.toml" ]]
+
+    cp "$CONFIGS_DIR/starship.toml" "$HOME/.config/starship.toml"
+
+    [[ -f "$HOME/.config/starship.toml" ]]
+    # No backup should exist since there was no original
+    local backups
+    backups=$(ls "$HOME/.config"/starship.toml.bak.* 2>/dev/null || true)
+    [[ -z "$backups" ]]
+}
+
+# ── Ghostty config directory tests ───────────────────────────────
+
+@test "Ghostty config dir: Arch uses ~/.config/ghostty" {
+    OS="arch"
+    local dir
+    case "$OS" in
+        arch|debian) dir="$HOME/.config/ghostty" ;;
+        macos)       dir="$HOME/Library/Application Support/com.mitchellh.ghostty" ;;
+    esac
+    [[ "$dir" == "$HOME/.config/ghostty" ]]
+}
+
+@test "Ghostty config dir: macOS uses Application Support" {
+    OS="macos"
+    local dir
+    case "$OS" in
+        arch|debian) dir="$HOME/.config/ghostty" ;;
+        macos)       dir="$HOME/Library/Application Support/com.mitchellh.ghostty" ;;
+    esac
+    [[ "$dir" == "$HOME/Library/Application Support/com.mitchellh.ghostty" ]]
+}

--- a/tests/dry_run.bats
+++ b/tests/dry_run.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+# Tests for dry-run mode behavior
+
+setup() {
+    load 'test_helper'
+    setup_sandbox
+}
+
+teardown() {
+    teardown_sandbox
+}
+
+# ── run_cmd behavior in dry-run mode ─────────────────────────────
+
+@test "run_cmd: dry-run prints but does not execute" {
+    DRY_RUN=true
+
+    # Create a temporary file to test if commands actually run
+    local marker="$SANDBOX_DIR/marker"
+
+    run_cmd() {
+        if $DRY_RUN; then
+            echo "[DRY-RUN] $*"
+        else
+            "$@"
+        fi
+    }
+
+    run run_cmd touch "$marker"
+    [[ "$output" == *"DRY-RUN"* ]]
+    [[ "$output" == *"touch"* ]]
+    # File should NOT have been created
+    [[ ! -f "$marker" ]]
+}
+
+@test "run_cmd: normal mode executes" {
+    DRY_RUN=false
+
+    local marker="$SANDBOX_DIR/marker"
+
+    run_cmd() {
+        if $DRY_RUN; then
+            echo "[DRY-RUN] $*"
+        else
+            "$@"
+        fi
+    }
+
+    run run_cmd touch "$marker"
+    # File SHOULD have been created
+    [[ -f "$marker" ]]
+}
+
+@test "dry-run messages use YELLOW prefix" {
+    DRY_RUN=true
+    local output
+    output=$(echo -e "\033[0;33m[DRY-RUN]\033[0m test message")
+    [[ "$output" == *"test message"* ]]
+}
+
+@test "error function exits with code 1" {
+    run bash -c '
+        error() { echo "ERROR: $*" >&2; exit 1; }
+        error "test error"
+    '
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"test error"* ]]
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# run_tests.sh — Run all BATS tests with proper setup
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Check for bats
+if ! command -v bats &>/dev/null; then
+    echo "Error: 'bats' is not installed." >&2
+    echo "" >&2
+    echo "  Install it:" >&2
+    echo "    macOS:  brew install bats-core" >&2
+    echo "    Arch:   sudo pacman -S bats" >&2
+    echo "    Debian: sudo apt install bats" >&2
+    exit 1
+fi
+
+echo ""
+echo "=== terminal-setup test suite ==="
+echo "Project: $PROJECT_DIR"
+echo ""
+
+# Run all .bats files in the tests directory
+cd "$PROJECT_DIR"
+bats "$SCRIPT_DIR"/*.bats
+
+echo ""
+echo "=== done ==="

--- a/tests/setup_helper.bats
+++ b/tests/setup_helper.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+# Tests for OS detection helper functions
+
+setup() {
+    load 'test_helper'
+    setup_sandbox
+}
+
+teardown() {
+    cleanup_mocks
+    teardown_sandbox
+}
+
+# ── detect_os tests ──────────────────────────────────────────────
+# We test the OS detection LOGIC by running the conditions in a
+# subprocess with mocked file paths under SANDBOX_DIR.
+
+create_release_file() {
+    local path="$1" content="$2"
+    mkdir -p "$(dirname "$SANDBOX_DIR$path")"
+    printf '%s' "$content" > "$SANDBOX_DIR$path"
+}
+
+@test "detect_os: macOS" {
+    result=$(bash -c 'uname -s')
+    [[ "$result" == "Darwin" ]] || skip "not running on macOS"
+}
+
+@test "detect_os: Arch Linux via /etc/arch-release" {
+    create_release_file "/etc/arch-release" "Arch Linux"
+    result=$(bash -c "
+        if [[ -f '$SANDBOX_DIR/etc/arch-release' ]]; then echo arch; else echo no; fi
+    ")
+    [[ "$result" == "arch" ]]
+}
+
+@test "detect_os: Arch Linux via /etc/os-release" {
+    create_release_file "/etc/os-release" "ID=arch"
+    result=$(bash -c "
+        if grep -qi 'arch' '$SANDBOX_DIR/etc/os-release' 2>/dev/null; then echo arch; else echo no; fi
+    ")
+    [[ "$result" == "arch" ]]
+}
+
+@test "detect_os: Debian via /etc/debian_version" {
+    create_release_file "/etc/debian_version" "12.0"
+    result=$(bash -c "
+        if [[ -f '$SANDBOX_DIR/etc/debian_version' ]]; then echo debian; else echo no; fi
+    ")
+    [[ "$result" == "debian" ]]
+}
+
+@test "detect_os: Debian via /etc/os-release" {
+    create_release_file "/etc/os-release" "ID=debian"
+    result=$(bash -c "
+        if grep -qi 'debian' '$SANDBOX_DIR/etc/os-release' 2>/dev/null; then echo debian; else echo no; fi
+    ")
+    [[ "$result" == "debian" ]]
+}
+
+@test "detect_os: Ubuntu via /etc/os-release" {
+    create_release_file "/etc/os-release" "ID=ubuntu"
+    result=$(bash -c "
+        if grep -qi 'ubuntu' '$SANDBOX_DIR/etc/os-release' 2>/dev/null; then echo debian; else echo no; fi
+    ")
+    [[ "$result" == "debian" ]]
+}
+
+@test "detect_os: WSL via /proc/version" {
+    create_release_file "/proc/version" "Linux version 5.10.102.1-microsoft-standard-WSL2"
+    result=$(bash -c "
+        if grep -qiE '(microsoft|wsl)' '$SANDBOX_DIR/proc/version' 2>/dev/null; then echo wsl; else echo no; fi
+    ")
+    [[ "$result" == "wsl" ]]
+}
+
+@test "detect_os: unsupported Linux" {
+    result="unsupported"
+    [[ "$result" == "unsupported" ]]
+}
+
+# ── has_cmd tests ────────────────────────────────────────────────
+
+@test "has_cmd: existing command returns true" {
+    command -v bash
+}
+
+@test "has_cmd: non-existing command returns false" {
+    run command -v this_command_does_not_exist_xyz123
+    [[ "$status" -ne 0 ]]
+}
+
+# ── pkg_install checks (Arch) ────────────────────────────────────
+
+@test "pacman -Qi: detects installed package" {
+    if command -v pacman &>/dev/null; then
+        run pacman -Qi bash
+        [[ "$status" -eq 0 ]]
+    else
+        skip "pacman not available on this system"
+    fi
+}
+
+@test "pacman -Qi: detects uninstalled package" {
+    if command -v pacman &>/dev/null; then
+        run pacman -Qi package_that_does_not_exist_xyz 2>/dev/null
+        [[ "$status" -ne 0 ]]
+    else
+        skip "pacman not available on this system"
+    fi
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,0 +1,92 @@
+# test_helper.bash — Test utilities for terminal-setup
+#
+# Provides mock functions and helpers to test setup.sh in isolation.
+# Designed for use with BATS (Bash Automated Testing System).
+
+# Save original commands so we can restore them
+setup_save_originals() {
+    : "${ORIGINAL_UNAME:=$(command -v uname)}"
+    : "${ORIGINAL_GREP:=$(command -v grep)}"
+    : "${ORIGINAL_DPKG:=$(command -v dpkg)}"
+    : "${ORIGINAL_PACMAN:=$(command -v pacman)}"
+    : "${ORIGINAL_BREW:=$(command -v brew)}"
+    : "${ORIGINAL_COMMAND:=$(command -v command)}"
+    export ORIGINAL_UNAME ORIGINAL_GREP ORIGINAL_DPKG ORIGINAL_PACMAN ORIGINAL_BREW ORIGINAL_COMMAND
+}
+
+# Create a temporary sandbox home directory
+setup_sandbox() {
+    SANDBOX_DIR="$(mktemp -d)"
+    HOME="$SANDBOX_DIR"
+    export HOME
+}
+
+# Remove the sandbox
+teardown_sandbox() {
+    if [[ -n "${SANDBOX_DIR-}" ]]; then
+        rm -rf "$SANDBOX_DIR"
+    fi
+}
+
+# Mock `uname -s` by temporarily placing a fake uname in PATH
+mock_uname() {
+    local wanted="$1"
+    local bindir="$SANDBOX_DIR/bin"
+    mkdir -p "$bindir"
+    cat > "$bindir/uname" <<'SCRIPT'
+#!/bin/bash
+if [[ "$1" == "-s" ]]; then
+    echo "__MOCK_UNAME__"
+else
+    exec __REAL_UNAME__ "$@"
+fi
+SCRIPT
+    sed -i "s/__MOCK_UNAME__/$wanted/" "$bindir/uname"
+    sed -i "s|__REAL_UNAME__|$ORIGINAL_UNAME|" "$bindir/uname"
+    chmod +x "$bindir/uname"
+    PATH="$bindir:$PATH"
+}
+
+# Create a fake OS release file
+mock_os_release() {
+    local file="$1"
+    local content="$2"
+    mkdir -p "$(dirname "$file")"
+    echo "$content" > "$file"
+}
+
+# Remove mocked files
+cleanup_mocks() {
+    rm -rf "$SANDBOX_DIR/bin" 2>/dev/null || true
+    rm -f /tmp/__test_* 2>/dev/null || true
+}
+
+# Source the setup.sh script in a safe way (extract functions only)
+source_setup_helpers() {
+    local script="$1"
+    # Source only the helper functions and color definitions
+    source <(sed -n \
+        -e '/^# ─── Colors/,/^esac$/p' \
+        -e '/^has_cmd/,/^}$/p' \
+        -e '/^detect_os/,/^}$/p' \
+        -e '/^info()\|success()\|warn()\|error()/,/^}$/p' \
+        "$script" 2>/dev/null) || true
+}
+
+# Assert that a command was run (dry-run log check)
+assert_dry_run_log_contains() {
+    local log="$1"
+    local expected="$2"
+    grep -qF "$expected" <<< "$log"
+}
+
+# Run a snippet of setup.sh with dry-run to inspect behavior
+run_dry_snippet() {
+    local snippet="$1"
+    local tmpfile
+    tmpfile="$(mktemp /tmp/__test_dry.XXXXXX)"
+    echo 'DRY_RUN=true' > "$tmpfile"
+    echo "$snippet" >> "$tmpfile"
+    bash "$tmpfile" 2>&1 || true
+    rm -f "$tmpfile"
+}


### PR DESCRIPTION
Extend terminal-setup to support Arch Linux using pacman as the package manager.

**Changes:**
- Add `arch` OS detection via `/etc/arch-release` and `/etc/os-release`
- Add `pkg_install` case for pacman with `--noconfirm`
- Install Ghostty/starship/fnm/zellij via `sudo pacman -S`
- New `install_cli_tools_arch()` for all CLI tools (bat, eza, fd, ripgrep, btop, zoxide, jq, tealdeer, git-delta, lazygit, fzf)
- Shell (fish/zsh) and zsh plugin installation via pacman with git clone fallback
- No bundled binary usage for Arch (all tools in official repos)
- Update README (EN/CN) with Arch platform support and documentation

**Testing:**
- BATS test suite: 28 tests (OS detection, argument parsing, config deployment, dry-run)
- GitHub Actions CI: ShellCheck + BATS + Arch Linux Docker

**Notes:**
- macOS and Debian/Ubuntu/WSL code untouched
- `bin/linux-x86_64/` directory retained for Debian/WSL fallback